### PR TITLE
[fix] 무한 스크롤 시 여러번 Fetching 되는 현상 해결

### DIFF
--- a/src/context/IssuelistProvider.tsx
+++ b/src/context/IssuelistProvider.tsx
@@ -10,7 +10,6 @@ export interface IssuelistContextProps {
   error: Error | null;
   fetchIssues: (page: number) => void;
   increasePage: () => void;
-  isInitialLoad: boolean;
 }
 
 export const IssuelistContext = createContext<IssuelistContextProps | undefined>(undefined);
@@ -18,7 +17,6 @@ export const IssuelistContext = createContext<IssuelistContextProps | undefined>
 export const IssuelistProvider = ({ children }: PropsWithChildren) => {
   const [issues, setIssues] = useState<issueDataType[][]>([]);
   const [page, setPage] = useState<number>(1);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [hasNextPage, setHasNextPage] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -44,7 +42,6 @@ export const IssuelistProvider = ({ children }: PropsWithChildren) => {
       setError(error as Error);
     } finally {
       setIsLoading(false);
-      setIsInitialLoad(false);
     }
   };
 
@@ -62,7 +59,6 @@ export const IssuelistProvider = ({ children }: PropsWithChildren) => {
         error,
         fetchIssues,
         increasePage,
-        isInitialLoad,
       }}
     >
       {children}

--- a/src/fetcher/IssueListFetcher.tsx
+++ b/src/fetcher/IssueListFetcher.tsx
@@ -6,7 +6,7 @@ import useIssueListInfiniteScroll from '@/hooks/useIssueListInfiniteScroll';
 import LoadingSpinner from '@/components/LoadingSpinner';
 
 export default function IssueListFetcher({ children }: React.PropsWithChildren) {
-  const { page, isLoading, error, fetchIssues, isInitialLoad } = useIssueListContext();
+  const { page, isLoading, error, fetchIssues } = useIssueListContext();
 
   const { targetRef } = useIssueListInfiniteScroll();
 
@@ -18,10 +18,12 @@ export default function IssueListFetcher({ children }: React.PropsWithChildren) 
     throw new Error();
   }
 
-  if (isInitialLoad) {
+  if (isLoading) {
     return (
       <>
+        {children}
         <LoadingSpinner />
+        <div ref={targetRef} />
       </>
     );
   }
@@ -29,7 +31,6 @@ export default function IssueListFetcher({ children }: React.PropsWithChildren) 
   return (
     <>
       {children}
-      {isLoading && <LoadingSpinner />}
       <div ref={targetRef} />
     </>
   );


### PR DESCRIPTION
- 이슈 목록 Fetcher 컴포넌트에서 Loading 시 이전 이슈 목록(children) 출력하도록 수정